### PR TITLE
Fix qastool qasc RPATH on macOS

### DIFF
--- a/ports/qastool/portfile.cmake
+++ b/ports/qastool/portfile.cmake
@@ -5,12 +5,17 @@ vcpkg_from_github(
     SHA512 32f26837444bcf123b8d4026a12955576ef73d52082151d76efb3eb014b656c700e12ef3ed0627fa58a714245c38bd85744e59e16517afda456381df9f4deb6f
 )
 
+if(VCPKG_TARGET_IS_OSX)
+    set(QASC_USE_LINK_RPATH_OPT "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DQAS_BUILD_EXAMPLES=OFF
         -DQAS_BUILD_MOC_EXE=OFF
         -DQAS_VCPKG_TOOLS_HINT=ON
+        ${QASC_USE_LINK_RPATH_OPT}
 )
 
 vcpkg_cmake_install()
@@ -18,11 +23,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT}
     CONFIG_PATH lib/cmake/${PORT}
 )
-
-if(VCPKG_TARGET_IS_OSX)
-    get_filename_component(qt_lib_dir "$ENV{QT_DIR}/../.." REALPATH)
-    execute_process(COMMAND install_name_tool -add_rpath "${qt_lib_dir}" "${CURRENT_PACKAGES_DIR}/tools/qastool/qasc")
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")


### PR DESCRIPTION
Use CMAKE_INSTALL_RPATH_USE_LINK_PATH to ensure the resulting binary has a correct RPATH to Qt installation. The original solution does not really work.